### PR TITLE
[Feat] #5 Pophory 공용 버튼 구현

### DIFF
--- a/pophory-TCA/pophory-TCA.xcodeproj/project.pbxproj
+++ b/pophory-TCA/pophory-TCA.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3797E0182C7ECCA200EC6E26 /* PophoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797E0172C7ECCA200EC6E26 /* PophoryButton.swift */; };
 		37CBFBF72C65B6390049332C /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 37CBFBF62C65B6390049332C /* ComposableArchitecture */; };
 		3B1C335A2C65B552001DB285 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3BC585262C6472AC003763AF /* Pretendard-Bold.otf */; };
 		3B1C335B2C65B552001DB285 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3BC585232C6472AB003763AF /* Pretendard-Medium.otf */; };
@@ -42,6 +43,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3797E0172C7ECCA200EC6E26 /* PophoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PophoryButton.swift; sourceTree = "<group>"; };
 		3B1C33602C65B5F3001DB285 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3B3B9BE32C675E6B00AF9D5C /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		3B3B9BE52C675E7400AF9D5C /* ViewModifier+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModifier+.swift"; sourceTree = "<group>"; };
@@ -89,6 +91,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3797E0162C7ECC5D00EC6E26 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				3797E0172C7ECCA200EC6E26 /* PophoryButton.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		3B00A4842C6B032000D851F1 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -316,6 +326,7 @@
 			children = (
 				3BC585162C6468F1003763AF /* Assets */,
 				3BC5851C2C646953003763AF /* Constants */,
+				3797E0162C7ECC5D00EC6E26 /* Components */,
 				3BC5851B2C646947003763AF /* Extensions */,
 				3BC5851A2C646942003763AF /* Firebase */,
 				3BC585192C64691A003763AF /* Utilities */,
@@ -537,6 +548,7 @@
 				3B3B9BE42C675E6B00AF9D5C /* View+.swift in Sources */,
 				3BC585352C64743E003763AF /* UIFontWithLineHeight.swift in Sources */,
 				3B3B9BE62C675E7400AF9D5C /* ViewModifier+.swift in Sources */,
+				3797E0182C7ECCA200EC6E26 /* PophoryButton.swift in Sources */,
 				3BC584D92C646530003763AF /* ContentView.swift in Sources */,
 				3BC584D72C646530003763AF /* pophory_TCAApp.swift in Sources */,
 			);

--- a/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
+++ b/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
@@ -1,0 +1,118 @@
+//
+//  PophoryButton.swift
+//  pophory-TCA
+//
+//  Created by Joon Baek on 2024/08/09.
+//
+
+import SwiftUI
+
+enum ButtonType {
+    case standard
+    case small
+    case custom
+    case appleLogin
+    
+    var fontStyle: UIFontWithLineHeight {
+        switch self {
+        case .standard, .custom, .appleLogin:
+            return .headline03SemiBold
+        case .small:
+            return .text01Medium
+        }
+    }
+    
+    var dimensions: (width: CGFloat, height: CGFloat) {
+        switch self {
+        case .standard, .custom, .appleLogin:
+            return (335, 60)
+        case .small:
+            return (248, 47)
+        }
+    }
+    
+    var foregroundColor: Color {
+        switch self {
+        case .standard, .small, .appleLogin:
+            return .white
+        case .custom:
+            return .pryPurple
+        }
+    }
+    
+    var isAppleLogin: Bool {
+        self == .appleLogin
+    }
+}
+
+struct PophoryButtonStyle: ButtonStyle {
+    let type: ButtonType
+    let backgroundColor: Color
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: type.dimensions.width, height: type.dimensions.height)
+            .background(backgroundColor)
+            .foregroundColor(type.foregroundColor)
+            .cornerRadius(30)
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+    }
+}
+
+struct PophoryButton: View {
+    let title: String
+    let action: () -> Void
+    let type: ButtonType
+    let backgroundColor: Color
+    
+    var body: some View {
+        Button(action: action) {
+            GeometryReader { geometry in
+                HStack {
+                    if type.isAppleLogin {
+                        appleLoginContent(geometry)
+                    } else {
+                        Text(title)
+                            .fontWithLineHeightView(fontType: type.fontStyle)
+                    }
+                }
+                // buttonLabel 쏠림 방지
+                .frame(width: geometry.size.width, height: geometry.size.height)
+            }
+        }
+        .buttonStyle(PophoryButtonStyle(type: type, backgroundColor: backgroundColor))
+    }
+}
+
+extension PophoryButton {
+    private func appleLoginContent(_ geometry: GeometryProxy) -> some View {
+        HStack {
+            Image(systemName: "apple.logo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20)
+                .padding(.leading, 20)
+            
+            Spacer()
+                .frame(width: geometry.size.width * 0.1)
+            
+            Text(title)
+                .fontWithLineHeightView(fontType: type.fontStyle)
+                .frame(maxWidth: .infinity)
+            
+            Spacer()
+                .frame(width: geometry.size.width * 0.2)
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        PophoryButton(title: "포포리 버튼", action: {}, type: .standard, backgroundColor: .pryBlack)
+        PophoryButton(title: "Apple ID로 시작하기", action: {}, type: .appleLogin, backgroundColor: .pryBlack)
+        PophoryButton(title: "커스텀 버튼", action: {}, type: .custom, backgroundColor: .white)
+        PophoryButton(title: "작은 버튼 그레이", action: {}, type: .small, backgroundColor: .gray400)
+    }
+    .background(Color.gray300)
+    .cornerRadius(30)
+}

--- a/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
+++ b/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
@@ -10,12 +10,11 @@ import SwiftUI
 enum ButtonType {
     case standard
     case small
-    case custom
     case appleLogin
     
     var fontStyle: UIFontWithLineHeight {
         switch self {
-        case .standard, .custom, .appleLogin:
+        case .standard, .appleLogin:
             return .headline03SemiBold
         case .small:
             return .text01Medium
@@ -24,24 +23,24 @@ enum ButtonType {
     
     var dimensions: (width: CGFloat, height: CGFloat) {
         switch self {
-        case .standard, .custom, .appleLogin:
+        case .standard, .appleLogin:
             return (335, 60)
         case .small:
             return (248, 47)
         }
     }
     
-    var foregroundColor: Color {
-        switch self {
-        case .standard, .small, .appleLogin:
-            return .white
-        case .custom:
-            return .pryPurple
-        }
-    }
-    
     var isAppleLogin: Bool {
         self == .appleLogin
+    }
+    
+    func setTextColor(for backgroundColor: Color) -> Color {
+        switch self {
+        case .standard:
+            return backgroundColor == .white ? .pryPurple : .white
+        case .small, .appleLogin:
+            return .white
+        }
     }
 }
 
@@ -53,7 +52,7 @@ struct PophoryButtonStyle: ButtonStyle {
         configuration.label
             .frame(width: type.dimensions.width, height: type.dimensions.height)
             .background(backgroundColor)
-            .foregroundColor(type.foregroundColor)
+            .foregroundColor(type.setTextColor(for: backgroundColor))
             .cornerRadius(30)
             .opacity(configuration.isPressed ? 0.8 : 1.0)
     }
@@ -110,7 +109,7 @@ extension PophoryButton {
     VStack(spacing: 20) {
         PophoryButton(title: "포포리 버튼", action: {}, type: .standard, backgroundColor: .pryBlack)
         PophoryButton(title: "Apple ID로 시작하기", action: {}, type: .appleLogin, backgroundColor: .pryBlack)
-        PophoryButton(title: "커스텀 버튼", action: {}, type: .custom, backgroundColor: .white)
+        PophoryButton(title: "화이트 버튼", action: {}, type: .standard, backgroundColor: .white)
         PophoryButton(title: "작은 버튼 그레이", action: {}, type: .small, backgroundColor: .gray400)
     }
     .background(Color.gray300)

--- a/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
+++ b/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
@@ -21,12 +21,12 @@ enum ButtonType {
         }
     }
     
-    var dimensions: (width: CGFloat, height: CGFloat) {
+    var height: CGFloat {
         switch self {
         case .standard, .appleLogin:
-            return (335, 60)
+            return 60
         case .small:
-            return (248, 47)
+            return 47
         }
     }
     
@@ -50,7 +50,7 @@ struct PophoryButtonStyle: ButtonStyle {
     
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: type.dimensions.width, height: type.dimensions.height)
+            .frame(maxWidth: .infinity, minHeight: type.height)
             .background(backgroundColor)
             .foregroundColor(type.setTextColor(for: backgroundColor))
             .cornerRadius(30)
@@ -66,25 +66,21 @@ struct PophoryButton: View {
     
     var body: some View {
         Button(action: action) {
-            GeometryReader { geometry in
-                HStack {
+                Group {
                     if type.isAppleLogin {
-                        appleLoginContent(geometry)
+                        appleLoginContent()
                     } else {
                         Text(title)
                             .fontWithLineHeightView(fontType: type.fontStyle)
                     }
                 }
-                // buttonLabel 쏠림 방지
-                .frame(width: geometry.size.width, height: geometry.size.height)
-            }
         }
         .buttonStyle(PophoryButtonStyle(type: type, backgroundColor: backgroundColor))
     }
 }
 
 extension PophoryButton {
-    private func appleLoginContent(_ geometry: GeometryProxy) -> some View {
+    private func appleLoginContent() -> some View {
         HStack {
             Image(systemName: "apple.logo")
                 .resizable()
@@ -93,14 +89,11 @@ extension PophoryButton {
                 .padding(.leading, 20)
             
             Spacer()
-                .frame(width: geometry.size.width * 0.1)
             
             Text(title)
                 .fontWithLineHeightView(fontType: type.fontStyle)
-                .frame(maxWidth: .infinity)
             
             Spacer()
-                .frame(width: geometry.size.width * 0.2)
         }
     }
 }

--- a/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
+++ b/pophory-TCA/pophory-TCA/Global/Components/PophoryButton.swift
@@ -59,9 +59,9 @@ struct PophoryButtonStyle: ButtonStyle {
 }
 
 struct PophoryButton: View {
+    let type: ButtonType
     let title: String
     let action: () -> Void
-    let type: ButtonType
     let backgroundColor: Color
     
     var body: some View {
@@ -107,11 +107,13 @@ extension PophoryButton {
 
 #Preview {
     VStack(spacing: 20) {
-        PophoryButton(title: "포포리 버튼", action: {}, type: .standard, backgroundColor: .pryBlack)
-        PophoryButton(title: "Apple ID로 시작하기", action: {}, type: .appleLogin, backgroundColor: .pryBlack)
-        PophoryButton(title: "화이트 버튼", action: {}, type: .standard, backgroundColor: .white)
-        PophoryButton(title: "작은 버튼 그레이", action: {}, type: .small, backgroundColor: .gray400)
+        PophoryButton(type: .standard, title: "포포리 버튼", action: {},  backgroundColor: .pryBlack)
+        PophoryButton(type: .appleLogin, title: "Apple ID로 시작하기", action: {},  backgroundColor: .pryBlack)
+        PophoryButton(type: .standard, title: "화이트 버튼", action: {}, backgroundColor: .white)
+        PophoryButton(type: .small, title: "작은 버튼 블랙", action: {},  backgroundColor: .pryBlack)
+        PophoryButton(type: .small, title: "작은 버튼 그레이", action: {},  backgroundColor: .gray400)
     }
+    .padding(20)
     .background(Color.gray300)
     .cornerRadius(30)
 }


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

재사용이 가능한 Button 구현

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

Pophory버튼은 아래와 같이 3개의 버튼 타입으로 이뤄져있습니다.
```swift
enum ButtonType {
    case standard
    case small
    case appleLogin
    }
```
PophoryButtonStyle에서 type에 따라 기본 속성 설정이 이뤄지구요, PophoryButton의 body에 buttonStyle 속성값으로 들어가는 구조입니다.

```swift
struct PophoryButtonStyle: ButtonStyle {
    let type: ButtonType
    let backgroundColor: Color
    
    func makeBody(configuration: Configuration) -> some View {
        configuration.label
            .frame(width: type.dimensions.width, height: type.dimensions.height)
            .background(backgroundColor)
            .foregroundColor(type.setTextColor(for: backgroundColor))
            .cornerRadius(30)
            .opacity(configuration.isPressed ? 0.8 : 1.0)
    }
}
```

```swift
struct PophoryButton: View {
// 생략   
    var body: some View {
    // 생략
        }
        .buttonStyle(PophoryButtonStyle(type: type, backgroundColor: backgroundColor))
    }
}
```

화이트 버튼은 배경색이 .white면 foregroundColor을 .pryPurple로 변경되도록 분기해 놓았습니다.

구현 초기에 제네릭과 프로토콜을 활용하여 추상화했었으나 포포리의 규모를 봤을 때 앞으로 디자인시스템이 크게 변경될 가능성이 낮아보여 enum 방식으로 더 간단히 구현하였습니다. 또한 customr값을 standard로 통합했습니다. 다양한 버튼들이 추가된다면 그때 제네릭과 프로토콜을 활용한 추상화해봐도 좋을 것 같은데 어떻게 생각하시나요?

### 사용법
```swift
        PophoryButton(type: .타입, title: "타이틀", action: {},  backgroundColor: .커스텀컬러)
```

추가적으로 현재 기기대응이 되어있지 않은 상태인데 다음 이슈에서 반영하겠습니다 :) 

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   GIF           | <img width="478" alt="image" src="https://github.com/user-attachments/assets/85535ce2-d556-48b8-b3ec-883d8fe4dafc" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #5 
